### PR TITLE
Implemented ability to bind to a specific address

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -197,7 +197,7 @@ class F1TelemetryClient extends EventEmitter {
     this.socket.on('message', (m) => this.handleMessage(m));
     this.socket.bind({
       port: this.port,
-      address: this.bindAddress,
+      address: this.address,
       exclusive: false,
     });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import {Address, Options, ParsedMessage} from './types';
 const DEFAULT_PORT = 20777;
 const FORWARD_ADDRESSES = undefined;
 const BIGINT_ENABLED = true;
+const BIND_ADDRESS = 'localhost';
 
 /**
  *
@@ -21,6 +22,7 @@ class F1TelemetryClient extends EventEmitter {
   port: number;
   bigintEnabled: boolean;
   forwardAddresses?: Address[];
+  bindAddress: string;
   socket?: dgram.Socket;
 
   constructor(opts: Options = {}) {
@@ -30,11 +32,13 @@ class F1TelemetryClient extends EventEmitter {
       port = DEFAULT_PORT,
       bigintEnabled = BIGINT_ENABLED,
       forwardAddresses = FORWARD_ADDRESSES,
+      bindAddress = BIND_ADDRESS,
     } = opts;
 
     this.port = port;
     this.bigintEnabled = bigintEnabled;
     this.forwardAddresses = forwardAddresses;
+    this.bindAddress = bindAddress;
     this.socket = dgram.createSocket('udp4');
   }
 
@@ -193,7 +197,7 @@ class F1TelemetryClient extends EventEmitter {
     this.socket.on('message', (m) => this.handleMessage(m));
     this.socket.bind({
       port: this.port,
-      address: 'localhost',
+      address: this.bindAddress,
       exclusive: false,
     });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import {Address, Options, ParsedMessage} from './types';
 const DEFAULT_PORT = 20777;
 const FORWARD_ADDRESSES = undefined;
 const BIGINT_ENABLED = true;
-const BIND_ADDRESS = 'localhost';
+const ADDRESS = 'localhost';
 
 /**
  *
@@ -22,7 +22,7 @@ class F1TelemetryClient extends EventEmitter {
   port: number;
   bigintEnabled: boolean;
   forwardAddresses?: Address[];
-  bindAddress: string;
+  address: string;
   socket?: dgram.Socket;
 
   constructor(opts: Options = {}) {
@@ -32,13 +32,13 @@ class F1TelemetryClient extends EventEmitter {
       port = DEFAULT_PORT,
       bigintEnabled = BIGINT_ENABLED,
       forwardAddresses = FORWARD_ADDRESSES,
-      bindAddress = BIND_ADDRESS,
+      address = ADDRESS,
     } = opts;
 
     this.port = port;
     this.bigintEnabled = bigintEnabled;
     this.forwardAddresses = forwardAddresses;
-    this.bindAddress = bindAddress;
+    this.address = address;
     this.socket = dgram.createSocket('udp4');
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export interface Options {
   forwardAddresses?: Address[]|undefined;
   bigintEnabled?: boolean;
   skipParsing?: boolean;
+  bindAddress?: string;
 }
 
 export interface Address {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ export interface Options {
   forwardAddresses?: Address[]|undefined;
   bigintEnabled?: boolean;
   skipParsing?: boolean;
-  bindAddress?: string;
+  address?: string;
 }
 
 export interface Address {


### PR DESCRIPTION
This is my proposed fix for #50 - this adds a new optional parameter to 'opts' when creating a client - which if not specified will default to the previous value of 'localhost'.